### PR TITLE
Inherit HTTPConnection through urllib3.connection, not http.client

### DIFF
--- a/requests_unixsocket/adapters.py
+++ b/requests_unixsocket/adapters.py
@@ -4,11 +4,6 @@ from requests.adapters import HTTPAdapter
 from requests.compat import urlparse, unquote
 
 try:
-    import http.client as httplib
-except ImportError:
-    import httplib
-
-try:
     from requests.packages import urllib3
 except ImportError:
     import urllib3
@@ -16,7 +11,7 @@ except ImportError:
 
 # The following was adapted from some code from docker-py
 # https://github.com/docker/docker-py/blob/master/docker/transport/unixconn.py
-class UnixHTTPConnection(httplib.HTTPConnection, object):
+class UnixHTTPConnection(urllib3.connection.HTTPConnection, object):
 
     def __init__(self, unix_socket_url, timeout=60):
         """Create an HTTP connection to a unix domain socket


### PR DESCRIPTION
Fix the incompatibility with requests 2.29.0 and urllib3 v2.